### PR TITLE
Add sort_fields_by_field_number option

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -77,6 +77,8 @@ type Node struct {
 	// Used when we want to break between the field name and values when a
 	// single-line node exceeds the requested wrap column.
 	PutSingleValueOnNextLine bool
+	// Field number from proto definition (0 if unknown/not applicable).
+	FieldNumber int32
 }
 
 // NodeLess is a sorting function that compares two *Nodes, possibly using the parent Node
@@ -265,6 +267,32 @@ func ByFieldSubfieldPath(field string, subfieldPath []string, projection func(st
 		}
 		return projection(vi.Value) < projection(vj.Value)
 	}
+}
+
+// ByFieldNumber is a NodeLess function that orders fields by their field numbers.
+// Field numbers are populated during parsing from descriptor information.
+func ByFieldNumber(_, ni, nj *Node, isWholeSlice bool) bool {
+	if !isWholeSlice {
+		return false
+	}
+
+	numI, numJ := ni.FieldNumber, nj.FieldNumber
+
+	// If both have field numbers, sort by field number
+	if numI > 0 && numJ > 0 {
+		return numI < numJ
+	}
+
+	// If only one has field number, prioritize it
+	if numI > 0 && numJ == 0 {
+		return true // ni has priority
+	}
+	if numI == 0 && numJ > 0 {
+		return false // nj has priority
+	}
+
+	// If neither has field number, fall back to alphabetical order
+	return ni.Name < nj.Name
 }
 
 // getChildValue returns the Value of the child with the given field name,

--- a/cmd/txtpbfmt/fmt.go
+++ b/cmd/txtpbfmt/fmt.go
@@ -24,6 +24,9 @@ var (
 	expandAllChildren                      = flag.Bool("expand_all_children", false, "Expand all children irrespective of initial state.")
 	skipAllColons                          = flag.Bool("skip_all_colons", false, "Skip colons whenever possible.")
 	sortFieldsByFieldName                  = flag.Bool("sort_fields_by_field_name", false, "Sort fields by field name.")
+	sortFieldsByFieldNumber                = flag.Bool("sort_fields_by_field_number", false, "Sort fields by field number from proto definition.")
+	protoDescriptor                        = flag.String("proto_descriptor", "", "Path to protobuf descriptor file (.desc)")
+	messageFullName                        = flag.String("message_full_name", "", "Full message type name for field number lookup (required, e.g. google.protobuf.Any)")
 	sortRepeatedFieldsByContent            = flag.Bool("sort_repeated_fields_by_content", false, "Sort adjacent scalar fields of the same field name by their contents.")
 	sortRepeatedFieldsBySubfield           = flag.String("sort_repeated_fields_by_subfield", "", "Sort adjacent message fields of the given field name by the contents of the given subfield.")
 	removeDuplicateValuesForRepeatedFields = flag.Bool("remove_duplicate_values_for_repeated_fields", false, "Remove lines that have the same field name and scalar value as another.")
@@ -88,6 +91,9 @@ func processPath(path string) error {
 		ExpandAllChildren:                      *expandAllChildren,
 		SkipAllColons:                          *skipAllColons,
 		SortFieldsByFieldName:                  *sortFieldsByFieldName,
+		SortFieldsByFieldNumber:                *sortFieldsByFieldNumber,
+		ProtoDescriptor:                        *protoDescriptor,
+		MessageFullName:                        *messageFullName,
 		SortRepeatedFieldsByContent:            *sortRepeatedFieldsByContent,
 		SortRepeatedFieldsBySubfield:           strings.Split(*sortRepeatedFieldsBySubfield, ","),
 		RemoveDuplicateValuesForRepeatedFields: *removeDuplicateValuesForRepeatedFields,

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,15 @@ type Config struct {
 	// Sort fields by field name.
 	SortFieldsByFieldName bool
 
+	// Sort fields by field number from proto definition.
+	SortFieldsByFieldNumber bool
+
+	// Path to protobuf descriptor file (.desc).
+	ProtoDescriptor string
+
+	// Full message type name for field number lookup (required, e.g. google.protobuf.Any).
+	MessageFullName string
+
 	// Sort adjacent scalar fields of the same field name by their contents.
 	SortRepeatedFieldsByContent bool
 

--- a/descriptor/descriptor.go
+++ b/descriptor/descriptor.go
@@ -1,0 +1,83 @@
+// Package descriptor provides functionality to load and parse Protocol Buffer descriptor files.
+package descriptor
+
+import (
+	"fmt"
+	"os"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// Loader provides functionality to load field numbers from descriptor files.
+type Loader struct {
+	descriptorFile string
+	files          *protoregistry.Files
+}
+
+// NewLoader creates a new descriptor loader for the given descriptor file.
+func NewLoader(descriptorFile string) *Loader {
+	return &Loader{
+		descriptorFile: descriptorFile,
+	}
+}
+
+// LoadDescriptor loads and parses the descriptor file.
+func (l *Loader) LoadDescriptor() error {
+	data, err := os.ReadFile(l.descriptorFile)
+	if err != nil {
+		return fmt.Errorf("failed to read descriptor file %s: %v", l.descriptorFile, err)
+	}
+
+	fileDescSet := &descriptorpb.FileDescriptorSet{}
+	if err := proto.Unmarshal(data, fileDescSet); err != nil {
+		return fmt.Errorf("failed to unmarshal descriptor file %s: %v", l.descriptorFile, err)
+	}
+
+	files, err := protodesc.NewFiles(fileDescSet)
+	if err != nil {
+		return fmt.Errorf("failed to create files from descriptor file %s: %v", l.descriptorFile, err)
+	}
+	l.files = files
+
+	return nil
+}
+
+// GetRootMessageDescriptor returns the root message descriptor for the specified messageFullName.
+// messageFullName is required and must be a valid full name (e.g., "google.protobuf.Any").
+func (l *Loader) GetRootMessageDescriptor(messageFullName string) (protoreflect.MessageDescriptor, error) {
+	if l.files == nil {
+		return nil, fmt.Errorf("descriptor not loaded, call LoadDescriptor() first")
+	}
+
+	if messageFullName == "" {
+		// Collect available messages to help user
+		var availableMessages []string
+		l.files.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+			messages := fd.Messages()
+			for i := 0; i < messages.Len(); i++ {
+				msg := messages.Get(i)
+				availableMessages = append(availableMessages, string(msg.FullName()))
+			}
+			return true
+		})
+
+		if len(availableMessages) == 0 {
+			return nil, fmt.Errorf("message_full_name is required, but no messages found in descriptor")
+		}
+		return nil, fmt.Errorf("message_full_name is required. Available messages: %v", availableMessages)
+	}
+
+	// Find specific message type
+	desc, err := l.files.FindDescriptorByName(protoreflect.FullName(messageFullName))
+	if err != nil {
+		return nil, fmt.Errorf("message type %s not found: %v", messageFullName, err)
+	}
+	if msgDesc, ok := desc.(protoreflect.MessageDescriptor); ok {
+		return msgDesc, nil
+	}
+	return nil, fmt.Errorf("%s is not a message type", messageFullName)
+}

--- a/descriptor/descriptor.go
+++ b/descriptor/descriptor.go
@@ -19,38 +19,37 @@ type Loader struct {
 }
 
 // NewLoader creates a new descriptor loader for the given descriptor file.
-func NewLoader(descriptorFile string) *Loader {
-	return &Loader{
-		descriptorFile: descriptorFile,
+func NewLoader(descriptorFile string) (*Loader, error) {
+	if descriptorFile == "" {
+		return nil, fmt.Errorf("descriptor file is required")
 	}
-}
 
-// LoadDescriptor loads and parses the descriptor file.
-func (l *Loader) LoadDescriptor() error {
-	data, err := os.ReadFile(l.descriptorFile)
+	data, err := os.ReadFile(descriptorFile)
 	if err != nil {
-		return fmt.Errorf("failed to read descriptor file %s: %v", l.descriptorFile, err)
+		return nil, fmt.Errorf("failed to read descriptor file %s: %v", descriptorFile, err)
 	}
 
 	fileDescSet := &descriptorpb.FileDescriptorSet{}
 	if err := proto.Unmarshal(data, fileDescSet); err != nil {
-		return fmt.Errorf("failed to unmarshal descriptor file %s: %v", l.descriptorFile, err)
+		return nil, fmt.Errorf("failed to unmarshal descriptor file %s: %v", descriptorFile, err)
 	}
 
 	files, err := protodesc.NewFiles(fileDescSet)
 	if err != nil {
-		return fmt.Errorf("failed to create files from descriptor file %s: %v", l.descriptorFile, err)
+		return nil, fmt.Errorf("failed to create files from descriptor file %s: %v", descriptorFile, err)
 	}
-	l.files = files
 
-	return nil
+	return &Loader{
+		descriptorFile: descriptorFile,
+		files:          files,
+	}, nil
 }
 
 // GetRootMessageDescriptor returns the root message descriptor for the specified messageFullName.
 // messageFullName is required and must be a valid full name (e.g., "google.protobuf.Any").
 func (l *Loader) GetRootMessageDescriptor(messageFullName string) (protoreflect.MessageDescriptor, error) {
 	if l.files == nil {
-		return nil, fmt.Errorf("descriptor not loaded, call LoadDescriptor() first")
+		return nil, fmt.Errorf("descriptor not loaded, call NewLoader() first")
 	}
 
 	if messageFullName == "" {
@@ -66,7 +65,7 @@ func (l *Loader) GetRootMessageDescriptor(messageFullName string) (protoreflect.
 		})
 
 		if len(availableMessages) == 0 {
-			return nil, fmt.Errorf("message_full_name is required, but no messages found in descriptor")
+			return nil, fmt.Errorf("No messages found in descriptor")
 		}
 		return nil, fmt.Errorf("message_full_name is required. Available messages: %v", availableMessages)
 	}

--- a/descriptor/descriptor_test.go
+++ b/descriptor/descriptor_test.go
@@ -1,0 +1,113 @@
+package descriptor
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadDescriptor(t *testing.T) {
+	descriptorFile := filepath.Join("..", "testdata", "sort_by_field_number_test.desc")
+
+	loader := NewLoader(descriptorFile)
+	err := loader.LoadDescriptor()
+	if err != nil {
+		t.Fatalf("Failed to load descriptor: %v", err)
+	}
+
+	if loader.files == nil {
+		t.Error("files should not be nil after loading")
+	}
+}
+
+func TestInvalidDescriptorFile(t *testing.T) {
+	loader := NewLoader("nonexistent.desc")
+	err := loader.LoadDescriptor()
+	if err == nil {
+		t.Error("Expected error when loading nonexistent descriptor file")
+	}
+}
+
+func TestGetRootMessageDescriptor(t *testing.T) {
+	descriptorFile := filepath.Join("..", "testdata", "test.desc")
+
+	loader := NewLoader(descriptorFile)
+	err := loader.LoadDescriptor()
+	if err != nil {
+		t.Fatalf("Failed to load descriptor: %v", err)
+	}
+
+	tests := []struct {
+		name            string
+		messageFullName string
+		expectError     bool
+		expectedName    string
+	}{
+		{
+			name:            "valid message full name - UserProfile",
+			messageFullName: "testproto.UserProfile",
+			expectError:     false,
+			expectedName:    "testproto.UserProfile",
+		},
+		{
+			name:            "valid message full name - ProductCatalog",
+			messageFullName: "testproto.ProductCatalog",
+			expectError:     false,
+			expectedName:    "testproto.ProductCatalog",
+		},
+		{
+			name:            "empty message full name - should error",
+			messageFullName: "",
+			expectError:     true,
+		},
+		{
+			name:            "non-existent message full name",
+			messageFullName: "testproto.NonExistentMessage",
+			expectError:     true,
+		},
+		{
+			name:            "invalid message full name format",
+			messageFullName: "InvalidName",
+			expectError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desc, err := loader.GetRootMessageDescriptor(tt.messageFullName)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error for messageFullName: %s, but got none", tt.messageFullName)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for messageFullName: %s, got: %v", tt.messageFullName, err)
+				}
+				if desc == nil {
+					t.Errorf("Expected descriptor for messageFullName: %s, but got nil", tt.messageFullName)
+				} else {
+					actualName := string(desc.FullName())
+					if actualName != tt.expectedName {
+						t.Errorf("Expected descriptor full name: %s, but got: %s", tt.expectedName, actualName)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestGetRootMessageDescriptorWithoutLoadDescriptor(t *testing.T) {
+	loader := NewLoader("any.desc")
+	// Don't call LoadDescriptor
+
+	_, err := loader.GetRootMessageDescriptor("testproto.UserProfile")
+	if err == nil {
+		t.Error("Expected error when calling GetRootMessageDescriptor without LoadDescriptor")
+	}
+
+	expectedError := "descriptor not loaded"
+	if !strings.Contains(err.Error(), expectedError) {
+		t.Errorf("Expected error to contain %q, but got: %v", expectedError, err)
+	}
+}

--- a/descriptor/descriptor_test.go
+++ b/descriptor/descriptor_test.go
@@ -2,112 +2,72 @@ package descriptor
 
 import (
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
-func TestLoadDescriptor(t *testing.T) {
-	descriptorFile := filepath.Join("..", "testdata", "sort_by_field_number_test.desc")
+func TestNewLoader(t *testing.T) {
+	t.Run("valid descriptor file", func(t *testing.T) {
+		descriptorFile := filepath.Join("..", "testdata", "test.desc")
+		loader, err := NewLoader(descriptorFile)
+		if err != nil {
+			t.Fatalf("Failed to create loader: %v", err)
+		}
+		if loader == nil {
+			t.Fatal("Expected non-nil loader")
+		}
+	})
 
-	loader := NewLoader(descriptorFile)
-	err := loader.LoadDescriptor()
-	if err != nil {
-		t.Fatalf("Failed to load descriptor: %v", err)
-	}
+	t.Run("empty descriptor file path", func(t *testing.T) {
+		_, err := NewLoader("")
+		if err == nil {
+			t.Error("Expected error for empty path")
+		}
+	})
 
-	if loader.files == nil {
-		t.Error("files should not be nil after loading")
-	}
-}
-
-func TestInvalidDescriptorFile(t *testing.T) {
-	loader := NewLoader("nonexistent.desc")
-	err := loader.LoadDescriptor()
-	if err == nil {
-		t.Error("Expected error when loading nonexistent descriptor file")
-	}
+	t.Run("non-existent file", func(t *testing.T) {
+		_, err := NewLoader("nonexistent.desc")
+		if err == nil {
+			t.Error("Expected error for non-existent file")
+		}
+	})
 }
 
 func TestGetRootMessageDescriptor(t *testing.T) {
 	descriptorFile := filepath.Join("..", "testdata", "test.desc")
-
-	loader := NewLoader(descriptorFile)
-	err := loader.LoadDescriptor()
+	loader, err := NewLoader(descriptorFile)
 	if err != nil {
-		t.Fatalf("Failed to load descriptor: %v", err)
+		t.Fatalf("Failed to create loader: %v", err)
 	}
 
 	tests := []struct {
 		name            string
 		messageFullName string
-		expectError     bool
-		expectedName    string
+		wantError       bool
 	}{
-		{
-			name:            "valid message full name - UserProfile",
-			messageFullName: "testproto.UserProfile",
-			expectError:     false,
-			expectedName:    "testproto.UserProfile",
-		},
-		{
-			name:            "valid message full name - ProductCatalog",
-			messageFullName: "testproto.ProductCatalog",
-			expectError:     false,
-			expectedName:    "testproto.ProductCatalog",
-		},
-		{
-			name:            "empty message full name - should error",
-			messageFullName: "",
-			expectError:     true,
-		},
-		{
-			name:            "non-existent message full name",
-			messageFullName: "testproto.NonExistentMessage",
-			expectError:     true,
-		},
-		{
-			name:            "invalid message full name format",
-			messageFullName: "InvalidName",
-			expectError:     true,
-		},
+		{"UserProfile", "testproto.UserProfile", false},
+		{"ProductCatalog", "testproto.ProductCatalog", false},
+		{"Level1Config", "testproto.Level1Config", false},
+		{"nested message", "testproto.Level1Config.Level2Config", false},
+		{"empty name", "", true},
+		{"non-existent", "testproto.NonExistent", true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			desc, err := loader.GetRootMessageDescriptor(tt.messageFullName)
 
-			if tt.expectError {
+			if tt.wantError {
 				if err == nil {
-					t.Errorf("Expected error for messageFullName: %s, but got none", tt.messageFullName)
+					t.Error("Expected error but got none")
 				}
 			} else {
 				if err != nil {
-					t.Errorf("Unexpected error for messageFullName: %s, got: %v", tt.messageFullName, err)
+					t.Errorf("Unexpected error: %v", err)
 				}
 				if desc == nil {
-					t.Errorf("Expected descriptor for messageFullName: %s, but got nil", tt.messageFullName)
-				} else {
-					actualName := string(desc.FullName())
-					if actualName != tt.expectedName {
-						t.Errorf("Expected descriptor full name: %s, but got: %s", tt.expectedName, actualName)
-					}
+					t.Error("Expected descriptor but got nil")
 				}
 			}
 		})
-	}
-}
-
-func TestGetRootMessageDescriptorWithoutLoadDescriptor(t *testing.T) {
-	loader := NewLoader("any.desc")
-	// Don't call LoadDescriptor
-
-	_, err := loader.GetRootMessageDescriptor("testproto.UserProfile")
-	if err == nil {
-		t.Error("Expected error when calling GetRootMessageDescriptor without LoadDescriptor")
-	}
-
-	expectedError := "descriptor not loaded"
-	if !strings.Contains(err.Error(), expectedError) {
-		t.Errorf("Expected error to contain %q, but got: %v", expectedError, err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mitchellh/go-wordwrap v1.0.1
+	google.golang.org/protobuf v1.33.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,3 +6,5 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=

--- a/impl/impl.go
+++ b/impl/impl.go
@@ -11,9 +11,11 @@ import (
 
 	"github.com/protocolbuffers/txtpbfmt/ast"
 	"github.com/protocolbuffers/txtpbfmt/config"
+	"github.com/protocolbuffers/txtpbfmt/descriptor"
 	"github.com/protocolbuffers/txtpbfmt/quote"
 	"github.com/protocolbuffers/txtpbfmt/sort"
 	"github.com/protocolbuffers/txtpbfmt/wrap"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 type parser struct {
@@ -148,13 +150,38 @@ func ParseWithMetaCommentConfig(in []byte, c config.Config) ([]*ast.Node, error)
 	if err != nil {
 		return nil, err
 	}
+
+	// Load descriptor if field number sorting is enabled
+	var rootDesc protoreflect.MessageDescriptor
+	if c.SortFieldsByFieldNumber {
+		if c.ProtoDescriptor == "" {
+			return nil, fmt.Errorf("proto_descriptor is required when using sort_fields_by_field_number")
+		}
+
+		if c.MessageFullName == "" {
+			return nil, fmt.Errorf("message_full_name is required when using proto_descriptor")
+		}
+
+		loader := descriptor.NewLoader(c.ProtoDescriptor)
+		if err := loader.LoadDescriptor(); err != nil {
+			return nil, fmt.Errorf("failed to load descriptor file %s: %v", c.ProtoDescriptor, err)
+		}
+
+		// Get root message descriptor
+		var err error
+		rootDesc, err = loader.GetRootMessageDescriptor(c.MessageFullName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get root message descriptor: %v", err)
+		}
+	}
+
 	if p.config.InfoLevel() {
 		p.config.Infof("p.in: %q", string(p.in))
 		p.config.Infof("p.length: %v", p.length)
 	}
 	// Although unnamed nodes aren't strictly allowed, some formats represent a
 	// list of protos as a list of unnamed top-level nodes.
-	nodes, _, err := p.parse( /*isRoot=*/ true)
+	nodes, _, err := p.parse( /*isRoot=*/ true, rootDesc)
 	if err != nil {
 		return nil, err
 	}
@@ -288,6 +315,35 @@ func newParser(in []byte, c config.Config) (*parser, error) {
 	return parser, nil
 }
 
+// getFieldNumber returns the field number for a given field name in the descriptor.
+func getFieldNumber(desc protoreflect.MessageDescriptor, fieldName string) int32 {
+	if desc == nil {
+		return 0
+	}
+
+	field := desc.Fields().ByTextName(fieldName)
+	if field == nil {
+		return 0
+	}
+	return int32(field.Number())
+}
+
+// findChildDescriptor finds the descriptor for a nested message field.
+func (p *parser) findChildDescriptor(desc protoreflect.MessageDescriptor, fieldName string) protoreflect.MessageDescriptor {
+	if desc == nil {
+		return nil
+	}
+
+	field := desc.Fields().ByTextName(fieldName)
+	if field == nil {
+		return nil
+	}
+	if field.Kind() == protoreflect.MessageKind {
+		return field.Message()
+	}
+	return nil
+}
+
 func (p *parser) nextInputIs(b byte) bool {
 	return p.index < p.length && p.in[p.index] == b
 }
@@ -398,7 +454,7 @@ func (p *parser) consumeOptionalSeparator() error {
 // format (sequence of messages, each of which passes proto.UnmarshalText()).
 // endPos is the position of the first character on the first line
 // after parsed nodes: that's the position to append more children.
-func (p *parser) parse(isRoot bool) (result []*ast.Node, endPos ast.Position, err error) {
+func (p *parser) parse(isRoot bool, desc protoreflect.MessageDescriptor) (result []*ast.Node, endPos ast.Position, err error) {
 	var res []*ast.Node
 	res = []*ast.Node{} // empty children is different from nil children
 	for ld := p.getLoopDetector(); p.index < p.length; {
@@ -505,6 +561,9 @@ func (p *parser) parse(isRoot bool) (result []*ast.Node, endPos ast.Position, er
 			return nil, ast.Position{}, err
 		}
 
+		// Set field number from descriptor if available
+		nd.FieldNumber = getFieldNumber(desc, nd.Name)
+
 		// Skip separator.
 		preCommentsBeforeColon, _ := p.skipWhiteSpaceAndReadComments(true /* multiLine */)
 		nd.SkipColon = !p.consume(':')
@@ -512,7 +571,7 @@ func (p *parser) parse(isRoot bool) (result []*ast.Node, endPos ast.Position, er
 		preCommentsAfterColon, _ := p.skipWhiteSpaceAndReadComments(true /* multiLine */)
 
 		if p.consume('{') || p.consume('<') {
-			if err := p.parseMessage(nd); err != nil {
+			if err := p.parseMessage(nd, desc); err != nil {
 				return nil, ast.Position{}, err
 			}
 		} else if p.consume('[') {
@@ -562,14 +621,15 @@ func (p *parser) parseFieldName(nd *ast.Node, isRoot bool) error {
 	return nil
 }
 
-func (p *parser) parseMessage(nd *ast.Node) error {
+func (p *parser) parseMessage(nd *ast.Node, desc protoreflect.MessageDescriptor) error {
 	if p.config.SkipAllColons {
 		nd.SkipColon = true
 	}
 	nd.ChildrenSameLine = p.bracketSameLine[p.index-1]
 	nd.IsAngleBracket = p.config.PreserveAngleBrackets && p.in[p.index-1] == '<'
 	// Recursive call to parse child nodes.
-	nodes, lastPos, err := p.parse( /*isRoot=*/ false)
+	childDesc := p.findChildDescriptor(desc, nd.Name)
+	nodes, lastPos, err := p.parse( /*isRoot=*/ false, childDesc)
 	if err != nil {
 		return err
 	}
@@ -595,7 +655,7 @@ func (p *parser) parseList(nd *ast.Node, preCommentsBeforeColon, preCommentsAfte
 		// Handle list of nodes.
 		nd.ChildrenAsList = true
 
-		nodes, lastPos, err := p.parse( /*isRoot=*/ true)
+		nodes, lastPos, err := p.parse( /*isRoot=*/ true, nil)
 		if err != nil {
 			return err
 		}

--- a/impl/impl.go
+++ b/impl/impl.go
@@ -158,17 +158,12 @@ func ParseWithMetaCommentConfig(in []byte, c config.Config) ([]*ast.Node, error)
 			return nil, fmt.Errorf("proto_descriptor is required when using sort_fields_by_field_number")
 		}
 
-		if c.MessageFullName == "" {
-			return nil, fmt.Errorf("message_full_name is required when using proto_descriptor")
-		}
-
-		loader := descriptor.NewLoader(c.ProtoDescriptor)
-		if err := loader.LoadDescriptor(); err != nil {
-			return nil, fmt.Errorf("failed to load descriptor file %s: %v", c.ProtoDescriptor, err)
+		loader, err := descriptor.NewLoader(c.ProtoDescriptor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create descriptor loader: %v", err)
 		}
 
 		// Get root message descriptor
-		var err error
 		rootDesc, err = loader.GetRootMessageDescriptor(c.MessageFullName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get root message descriptor: %v", err)

--- a/impl/impl_test.go
+++ b/impl/impl_test.go
@@ -1,9 +1,12 @@
 package impl
 
 import (
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kylelemons/godebug/pretty"
+	"github.com/protocolbuffers/txtpbfmt/config"
 )
 
 func TestPreprocess(t *testing.T) {
@@ -194,5 +197,180 @@ p        {}`,
 				t.Errorf("sameLineBrackets[%s] allowTripleQuotedStrings=true %v returned diff (-want, +have):\n%s", input.name, input.in, diff)
 			}
 		}
+	}
+}
+
+func TestParseWithMetaCommentConfig_ErrorHandling(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         config.Config
+		input          string
+		expectError    bool
+		errorSubstring string
+	}{
+		{
+			name: "SortFieldsByFieldNumber without ProtoDescriptor",
+			config: config.Config{
+				SortFieldsByFieldNumber: true,
+				ProtoDescriptor:         "",
+				MessageFullName:         "testproto.UserProfile",
+			},
+			input:          `name: "test"`,
+			expectError:    true,
+			errorSubstring: "proto_descriptor is required",
+		},
+		{
+			name: "SortFieldsByFieldNumber without MessageFullName",
+			config: config.Config{
+				SortFieldsByFieldNumber: true,
+				ProtoDescriptor:         "testdata/test.desc",
+				MessageFullName:         "",
+			},
+			input:          `name: "test"`,
+			expectError:    true,
+			errorSubstring: "message_full_name is required",
+		},
+		{
+			name: "SortFieldsByFieldNumber with invalid descriptor file",
+			config: config.Config{
+				SortFieldsByFieldNumber: true,
+				ProtoDescriptor:         "nonexistent.desc",
+				MessageFullName:         "testproto.UserProfile",
+			},
+			input:          `name: "test"`,
+			expectError:    true,
+			errorSubstring: "failed to load descriptor file",
+		},
+		{
+			name: "SortFieldsByFieldNumber with invalid message name",
+			config: config.Config{
+				SortFieldsByFieldNumber: true,
+				ProtoDescriptor:         filepath.Join("..", "testdata", "test.desc"),
+				MessageFullName:         "testproto.NonExistentMessage",
+			},
+			input:          `name: "test"`,
+			expectError:    true,
+			errorSubstring: "failed to get root message descriptor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseWithMetaCommentConfig([]byte(tt.input), tt.config)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error for test %s, but got none", tt.name)
+				} else if !strings.Contains(err.Error(), tt.errorSubstring) {
+					t.Errorf("Expected error to contain %q, but got: %v", tt.errorSubstring, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for test %s: %v", tt.name, err)
+				}
+			}
+		})
+	}
+}
+
+func TestParseWithMetaCommentConfig_SortFieldsByFieldNumber(t *testing.T) {
+	descriptorFile := filepath.Join("..", "testdata", "test.desc")
+
+	tests := []struct {
+		name                  string
+		config                config.Config
+		input                 string
+		expectSuccess         bool
+		expectedFieldsInOrder []string // Expected field names in order
+	}{
+		{
+			name: "Sort fields by field number - UserProfile",
+			config: config.Config{
+				SortFieldsByFieldNumber: true,
+				ProtoDescriptor:         descriptorFile,
+				MessageFullName:         "testproto.UserProfile",
+			},
+			input: `name: "test"
+priority: 10
+id: 1
+email: "test@example.com"
+active: true`,
+			expectSuccess: true,
+			// Expected order based on field numbers: id=1, priority=2, email=3, name=5, active=7
+			expectedFieldsInOrder: []string{"id", "priority", "email", "name", "active"},
+		},
+		{
+			name: "Sort fields by field number - ProductCatalog",
+			config: config.Config{
+				SortFieldsByFieldNumber: true,
+				ProtoDescriptor:         descriptorFile,
+				MessageFullName:         "testproto.ProductCatalog",
+			},
+			input: `name: "product_test"
+priority: 100
+id: 1
+enabled: true`,
+			expectSuccess: true,
+			// Expected order based on field numbers: id=1, enabled=2, name=3, priority=4
+			expectedFieldsInOrder: []string{"id", "enabled", "name", "priority"},
+		},
+		{
+			name: "Regular parsing without field number sorting",
+			config: config.Config{
+				SortFieldsByFieldNumber: false,
+			},
+			input: `name: "test"
+priority: 10
+id: 1`,
+			expectSuccess: true,
+			// Should maintain original order
+			expectedFieldsInOrder: []string{"name", "priority", "id"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, err := ParseWithMetaCommentConfig([]byte(tt.input), tt.config)
+
+			if tt.expectSuccess {
+				if err != nil {
+					t.Fatalf("Unexpected error for test %s: %v", tt.name, err)
+				}
+
+				if len(nodes) == 0 {
+					t.Fatalf("Expected nodes but got empty result for test %s", tt.name)
+				}
+
+				// Extract field names in order
+				var actualFieldOrder []string
+				for _, node := range nodes {
+					if node.Name != "" {
+						actualFieldOrder = append(actualFieldOrder, node.Name)
+					}
+				}
+
+				// Compare with expected order
+				if len(actualFieldOrder) != len(tt.expectedFieldsInOrder) {
+					t.Errorf("Expected %d fields, but got %d for test %s",
+						len(tt.expectedFieldsInOrder), len(actualFieldOrder), tt.name)
+				}
+
+				for i, expected := range tt.expectedFieldsInOrder {
+					if i >= len(actualFieldOrder) {
+						t.Errorf("Missing field at index %d, expected %s for test %s",
+							i, expected, tt.name)
+						break
+					}
+					if actualFieldOrder[i] != expected {
+						t.Errorf("Field at index %d: expected %s, got %s for test %s",
+							i, expected, actualFieldOrder[i], tt.name)
+					}
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Expected error for test %s, but parsing succeeded", tt.name)
+				}
+			}
+		})
 	}
 }

--- a/impl/impl_test.go
+++ b/impl/impl_test.go
@@ -223,7 +223,7 @@ func TestParseWithMetaCommentConfig_ErrorHandling(t *testing.T) {
 			name: "SortFieldsByFieldNumber without MessageFullName",
 			config: config.Config{
 				SortFieldsByFieldNumber: true,
-				ProtoDescriptor:         "testdata/test.desc",
+				ProtoDescriptor:         filepath.Join("..", "testdata", "test.desc"),
 				MessageFullName:         "",
 			},
 			input:          `name: "test"`,
@@ -239,7 +239,7 @@ func TestParseWithMetaCommentConfig_ErrorHandling(t *testing.T) {
 			},
 			input:          `name: "test"`,
 			expectError:    true,
-			errorSubstring: "failed to load descriptor file",
+			errorSubstring: "failed to read descriptor file",
 		},
 		{
 			name: "SortFieldsByFieldNumber with invalid message name",

--- a/sort/sort.go
+++ b/sort/sort.go
@@ -143,6 +143,9 @@ func nodeSortFunctionConfig(c config.Config) nodeSortFunction {
 	if c.SortFieldsByFieldName {
 		sorter = ast.ChainNodeLess(sorter, ast.ByFieldName)
 	}
+	if c.SortFieldsByFieldNumber {
+		sorter = ast.ChainNodeLess(sorter, ast.ByFieldNumber)
+	}
 	projection := identityProjection
 	if c.DNSSortOrder {
 		projection = dnsProjection

--- a/testdata/test.desc
+++ b/testdata/test.desc
@@ -1,0 +1,27 @@
+
+Š
+testdata/test.proto	testproto"¬
+UserProfile
+id (Rid
+priority (Rpriority
+email (	Remail
+name (	Rname
+active (Ractive/
+config
+ (2.testproto.Level1ConfigRconfig"j
+ProductCatalog
+id (Rid
+enabled (Renabled
+name (	Rname
+priority (Rpriority"”
+Level1Config
+id (Rid
+enabled (Renabled
+name (	Rname
+priority (Rpriority<
+level2 (2$.testproto.Level1Config.Level2ConfigRlevel2l
+Level2Config
+name (	Rname
+value (	Rvalue
+active (Ractive
+priority (RpriorityB.Z,github.com/protocolbuffers/txtpbfmt/testdatabproto3

--- a/testdata/test.proto
+++ b/testdata/test.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package testproto;
+
+option go_package = "github.com/protocolbuffers/txtpbfmt/testdata";
+
+message UserProfile {
+  int32 id = 1;
+  int32 priority = 2;
+  string email = 3;
+  string name = 5;
+  bool active = 7;
+  
+  Level1Config config = 10;
+}
+
+message ProductCatalog {
+  int32 id = 1;
+  bool enabled = 2;
+  string name = 3;
+  int32 priority = 4;
+}
+
+message Level1Config {
+  message Level2Config {
+    string name = 1;
+    string value = 2;
+    bool active = 3;
+    int32 priority = 4;
+  }
+
+  int32 id = 1;
+  bool enabled = 2;
+  string name = 3;
+  int32 priority = 4;
+  
+  Level2Config level2 = 5;
+}


### PR DESCRIPTION
resolves #178 

I added sort_fields_by_field_number and other two required options to the txtpbfmt.

## Changes

### Sorting Options

I added options below:
- sort_fields_by_field_number
- proto_descriptor
- message_full_name

proto_descriptor and message_full_name is required to resolve proto reference.  
For the convenience, possible message names are included in the error when the user did not put message_full_name option.

This is implemented by adding `FieldNumber` to AST Node struct, while carrying the proto descriptor during `parser.parse`.

## Example usage

```bash
go build -o txtpbfmt cmd/txtpbfmt/fmt.go
./txtpbfmt --sort_fields_by_field_number --proto_descriptor testdata/test.desc --message_full_name testproto.UserProfile example_input.textproto
```

before
```proto
active: true
config {
  enabled: true
  id: 42
  level2 {
    active: false
    name: "config_name"
    priority: 1
    value: "important"
  }
  name: "production"
  priority: 100
}
email: "a@example.com"
id: 123
name: "A"
priority: 5
```
after
```proto
id: 123
priority: 5
email: "a@example.com"
name: "A"
active: true
config {
  id: 42
  enabled: true
  name: "production"
  priority: 100
  level2 {
    name: "config_name"
    value: "important"
    active: false
    priority: 1
  }
}
```
